### PR TITLE
Root 뷰를 GestureHandlerRootView 로 감싸도록 변경

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,8 @@
 import React, { Suspense } from 'react';
-import { DripsyProvider } from 'dripsy';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { NavigationContainer } from '@react-navigation/native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { DripsyProvider } from 'dripsy';
 import { SplashScreen } from 'src/screens';
 import { themeLight } from 'src/themes';
 import type { PropsWithChildren } from 'react';
@@ -9,15 +10,19 @@ import type { PropsWithChildren } from 'react';
 // eslint-disable-next-line import/no-named-as-default-member
 const Navigator = React.lazy(() => import('src/navigators'));
 
+const gestureHandlerStyle = { flex: 1 } as const;
+
 function AppProviders<T = unknown>({ children }: PropsWithChildren<T>): JSX.Element {
   return (
-    <SafeAreaProvider>
-      <DripsyProvider theme={themeLight}>
-        <NavigationContainer>
-          {children}
-        </NavigationContainer>
-      </DripsyProvider>
-    </SafeAreaProvider>
+    <GestureHandlerRootView style={gestureHandlerStyle}>
+      <SafeAreaProvider>
+        <DripsyProvider theme={themeLight}>
+          <NavigationContainer>
+            {children}
+          </NavigationContainer>
+        </DripsyProvider>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
   );
 }
 


### PR DESCRIPTION
# Description

react-native-gesture-handler 공식 문서에 맞게 수정

## Changes

- root 뷰를 GestureHandlerRootView 로 감싸도록 수정

close #23