### PR TITLE
웹 react 18 대응을 위해 ReactDOM API 변경

### DIFF
--- a/patches/react-native-web+0.18.10.patch
+++ b/patches/react-native-web+0.18.10.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/react-native-web/dist/exports/render/index.js b/node_modules/react-native-web/dist/exports/render/index.js
+index 85f6fad..06e1180 100644
+--- a/node_modules/react-native-web/dist/exports/render/index.js
++++ b/node_modules/react-native-web/dist/exports/render/index.js
+@@ -6,13 +6,14 @@
+  *
+  * 
+  */
+-import { hydrate as domHydrate, render as domRender } from 'react-dom';
++import { hydrate as domHydrate } from 'react-dom';
++import { createRoot } from 'react-dom/client';
+ import { createSheet } from '../StyleSheet/dom';
+ export function hydrate(element, root, callback) {
+   createSheet(root);
+   return domHydrate(element, root, callback);
+ }
+-export default function render(element, root, callback) {
++export default function render(element, root, _callback) {
+   createSheet(root);
+-  return domRender(element, root, callback);
++  return createRoot(root).render(element);
+ }


### PR DESCRIPTION
# Description

react-native-web 의 경우 과거에 사용하던 render 함수를 사용하고 있음.
React 18 기능을 정상적으로 사용하기 위해 createRoot 기반 API 로 변경하는 패치 파일을 추가함

## Screenshots

| Before | After |
|:---:|:---:|
| <img width="483" alt="image" src="https://user-images.githubusercontent.com/26512984/203371951-0cf013cc-1af7-4dd4-872d-a8e789b970ed.png"> | <img width="550" alt="image" src="https://user-images.githubusercontent.com/26512984/203371748-3ad412fb-ff76-4bd2-a9ab-f4a11a58164b.png"> |




close #39