### PR TITLE
네이티브 폰트 정렬 이슈 수정

### DIFF
--- a/.ondevice/storybook.requires.js
+++ b/.ondevice/storybook.requires.js
@@ -33,9 +33,13 @@ const getStories = () => {
   return [
     require("../src/components/Demo.stories.tsx"),
     require("../src/designs/atoms/Button/Button.stories.tsx"),
+    require("../src/designs/atoms/H1/H1.stories.tsx"),
+    require("../src/designs/atoms/H2/H2.stories.tsx"),
+    require("../src/designs/atoms/H3/H3.stories.tsx"),
     require("../src/designs/atoms/Input/Input.stories.tsx"),
     require("../src/designs/atoms/ProgressBar/ProgressBar.stories.tsx"),
     require("../src/designs/atoms/Tag/Tag.stories.tsx"),
+    require("../src/designs/atoms/Text/Text.stories.tsx"),
   ];
 };
 

--- a/src/components/Demo.tsx
+++ b/src/components/Demo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ScrollView } from 'react-native';
-import { H1, H2, H3, P } from 'dripsy';
 import { colors } from 'src/themes/colors';
+import { H1, H2, H3, Text } from 'src/designs';
 
 export interface DemoProps { text: string }
 
@@ -11,9 +11,9 @@ export function Demo ({ text }: DemoProps): JSX.Element {
       <H1>Heading 1</H1>
       <H2>Heading 2</H2>
       <H3>Heading 3</H3>
-      <P>Default: {text}</P>
+      <Text>Default: {text}</Text>
       {Object.keys(colors).map((color) => {
-        return <P key={color} sx={{ color }}>{`${color}: ${text}`}</P>;
+        return <Text key={color} sx={{ color }}>{`${color}: ${text}`}</Text>;
       })}
     </ScrollView>
   );

--- a/src/designs/atoms/H1/H1.stories.tsx
+++ b/src/designs/atoms/H1/H1.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { View } from 'dripsy';
+import { H1 } from './H1';
+
+import type { ComponentProps } from 'react';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+export default {
+  title: 'components/H1',
+  component: H1,
+} as ComponentMeta<typeof H1>;
+
+type H1Props = ComponentProps<typeof H1>;
+type H1Story = ComponentStory<typeof H1>;
+
+const Template = (args: H1Props) => (
+  <View sx={{ flex: 1, padding: '$04' }}>
+    <H1 {...args} />
+  </View>
+);
+
+export const Default: H1Story = (args: H1Props) => {
+  return <Template {...args} />;
+};
+
+Default.args = {
+  children: 'Heading 1',
+};

--- a/src/designs/atoms/H1/H1.ts
+++ b/src/designs/atoms/H1/H1.ts
@@ -1,0 +1,19 @@
+import { createElement } from 'react';
+import { H1 as DripsyH1 } from 'dripsy';
+import { overrideHeadingStyle } from 'src/themes';
+
+import type { ComponentPropsWithRef } from 'react';
+ 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface H1Props extends ComponentPropsWithRef<typeof DripsyH1> {}
+
+export function H1 ({ children, style, ...restProps }: H1Props): JSX.Element {
+  return createElement(
+    DripsyH1,
+    {
+      ...restProps,
+      style: [overrideHeadingStyle, style],
+    },
+    children
+  );
+}

--- a/src/designs/atoms/H1/__tests__/H1.spec.tsx
+++ b/src/designs/atoms/H1/__tests__/H1.spec.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render as testRender, cleanup } from '@testing-library/react-native';
+import { withDripsy } from 'tests/utils';
+import { H1 } from '../H1';
+
+import type { H1Props } from '../H1';
+
+const render = (props: H1Props): ReturnType<typeof testRender> =>
+  testRender(withDripsy(<H1 {...props} />));
+
+describe('atoms/H1', () => {
+  const LABEL = 'Heading 1';
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('렌더링 되었을 때', () => {  
+    it('스냅샷이 일치해야 한다', () => {
+      const tree = render({ children: LABEL }).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/designs/atoms/H1/__tests__/__snapshots__/H1.spec.tsx.snap
+++ b/src/designs/atoms/H1/__tests__/__snapshots__/H1.spec.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`atoms/H1 렌더링 되었을 때 스냅샷이 일치해야 한다 1`] = `
+<Text
+  accessibilityRole="header"
+  style={
+    Array [
+      Object {
+        "fontSize": 64,
+        "fontWeight": "bold",
+        "marginVertical": 21.44,
+      },
+      Array [
+        Object {
+          "fontFamily": "BMJUA",
+          "fontSize": 24,
+          "marginVertical": 0,
+          "paddingBottom": 4,
+        },
+        Object {
+          "fontWeight": "normal",
+        },
+        undefined,
+        Object {},
+      ],
+    ]
+  }
+>
+  Heading 1
+</Text>
+`;

--- a/src/designs/atoms/H1/index.ts
+++ b/src/designs/atoms/H1/index.ts
@@ -1,0 +1,1 @@
+export * from './H1';

--- a/src/designs/atoms/H1/index.web.ts
+++ b/src/designs/atoms/H1/index.web.ts
@@ -1,0 +1,3 @@
+import { H1 as DripsyH1 } from 'dripsy';
+
+export const H1 = DripsyH1;

--- a/src/designs/atoms/H2/H2.stories.tsx
+++ b/src/designs/atoms/H2/H2.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { View } from 'dripsy';
+import { H2 } from './H2';
+
+import type { ComponentProps } from 'react';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+export default {
+  title: 'components/H2',
+  component: H2,
+} as ComponentMeta<typeof H2>;
+
+type H2Props = ComponentProps<typeof H2>;
+type H2Story = ComponentStory<typeof H2>;
+
+const Template = (args: H2Props) => (
+  <View sx={{ flex: 1, padding: '$04' }}>
+    <H2 {...args} />
+  </View>
+);
+
+export const Default: H2Story = (args: H2Props) => {
+  return <Template {...args} />;
+};
+
+Default.args = {
+  children: 'Heading 2',
+};

--- a/src/designs/atoms/H2/H2.ts
+++ b/src/designs/atoms/H2/H2.ts
@@ -1,0 +1,19 @@
+import { createElement } from 'react';
+import { H2 as DripsyH2 } from 'dripsy';
+import { overrideHeadingStyle } from 'src/themes';
+
+import type { ComponentPropsWithRef } from 'react';
+ 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface H2Props extends ComponentPropsWithRef<typeof DripsyH2> {}
+
+export function H2 ({ children, style, ...restProps }: H2Props): JSX.Element {
+  return createElement(
+    DripsyH2,
+    {
+      ...restProps,
+      style: [overrideHeadingStyle, style],
+    },
+    children
+  );
+}

--- a/src/designs/atoms/H2/__tests__/H2.spec.tsx
+++ b/src/designs/atoms/H2/__tests__/H2.spec.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render as testRender, cleanup } from '@testing-library/react-native';
+import { withDripsy } from 'tests/utils';
+import { H2 } from '../H2';
+
+import type { H2Props } from '../H2';
+
+const render = (props: H2Props): ReturnType<typeof testRender> =>
+  testRender(withDripsy(<H2 {...props} />));
+
+describe('atoms/H2', () => {
+  const LABEL = 'Heading 2';
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('렌더링 되었을 때', () => {  
+    it('스냅샷이 일치해야 한다', () => {
+      const tree = render({ children: LABEL }).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/designs/atoms/H2/__tests__/__snapshots__/H2.spec.tsx.snap
+++ b/src/designs/atoms/H2/__tests__/__snapshots__/H2.spec.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`atoms/H2 렌더링 되었을 때 스냅샷이 일치해야 한다 1`] = `
+<Text
+  accessibilityRole="header"
+  style={
+    Array [
+      Object {
+        "fontSize": 48,
+        "fontWeight": "bold",
+        "marginVertical": 26.56,
+      },
+      Array [
+        Object {
+          "fontFamily": "BMJUA",
+          "fontSize": 20,
+          "marginVertical": 0,
+          "paddingBottom": 4,
+        },
+        Object {
+          "fontWeight": "normal",
+        },
+        undefined,
+        Object {},
+      ],
+    ]
+  }
+>
+  Heading 2
+</Text>
+`;

--- a/src/designs/atoms/H2/index.ts
+++ b/src/designs/atoms/H2/index.ts
@@ -1,0 +1,1 @@
+export * from './H2';

--- a/src/designs/atoms/H2/index.web.ts
+++ b/src/designs/atoms/H2/index.web.ts
@@ -1,0 +1,3 @@
+import { H2 as DripsyH2 } from 'dripsy';
+
+export const H2 = DripsyH2;

--- a/src/designs/atoms/H3/H3.stories.tsx
+++ b/src/designs/atoms/H3/H3.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { View } from 'dripsy';
+import { H3 } from './H3';
+
+import type { ComponentProps } from 'react';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+export default {
+  title: 'components/H3',
+  component: H3,
+} as ComponentMeta<typeof H3>;
+
+type H3Props = ComponentProps<typeof H3>;
+type H3Story = ComponentStory<typeof H3>;
+
+const Template = (args: H3Props) => (
+  <View sx={{ flex: 1, padding: '$04' }}>
+    <H3 {...args} />
+  </View>
+);
+
+export const Default: H3Story = (args: H3Props) => {
+  return <Template {...args} />;
+};
+
+Default.args = {
+  children: 'Heading 3',
+};

--- a/src/designs/atoms/H3/H3.ts
+++ b/src/designs/atoms/H3/H3.ts
@@ -1,0 +1,19 @@
+import { createElement } from 'react';
+import { H3 as DripsyH3 } from 'dripsy';
+import { overrideHeadingStyle } from 'src/themes';
+
+import type { ComponentPropsWithRef } from 'react';
+ 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface H3Props extends ComponentPropsWithRef<typeof DripsyH3> {}
+
+export function H3 ({ children, style, ...restProps }: H3Props): JSX.Element {
+  return createElement(
+    DripsyH3,
+    {
+      ...restProps,
+      style: [overrideHeadingStyle, style],
+    },
+    children
+  );
+}

--- a/src/designs/atoms/H3/__tests__/H2.spec.tsx
+++ b/src/designs/atoms/H3/__tests__/H2.spec.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render as testRender, cleanup } from '@testing-library/react-native';
+import { withDripsy } from 'tests/utils';
+import { H3 } from '../H3';
+
+import type { H3Props } from '../H3';
+
+const render = (props: H3Props): ReturnType<typeof testRender> =>
+  testRender(withDripsy(<H3 {...props} />));
+
+describe('atoms/H3', () => {
+  const LABEL = 'Heading 3';
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('렌더링 되었을 때', () => {  
+    it('스냅샷이 일치해야 한다', () => {
+      const tree = render({ children: LABEL }).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/designs/atoms/H3/__tests__/__snapshots__/H2.spec.tsx.snap
+++ b/src/designs/atoms/H3/__tests__/__snapshots__/H2.spec.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`atoms/H3 렌더링 되었을 때 스냅샷이 일치해야 한다 1`] = `
+<Text
+  accessibilityRole="header"
+  style={
+    Array [
+      Object {
+        "fontSize": 37.44,
+        "fontWeight": "bold",
+        "marginVertical": 32,
+      },
+      Array [
+        Object {
+          "fontFamily": "BMJUA",
+          "fontSize": 16,
+          "marginVertical": 0,
+          "paddingBottom": 4,
+        },
+        Object {
+          "fontWeight": "normal",
+        },
+        undefined,
+        Object {},
+      ],
+    ]
+  }
+>
+  Heading 3
+</Text>
+`;

--- a/src/designs/atoms/H3/index.ts
+++ b/src/designs/atoms/H3/index.ts
@@ -1,0 +1,1 @@
+export * from './H3';

--- a/src/designs/atoms/H3/index.web.ts
+++ b/src/designs/atoms/H3/index.web.ts
@@ -1,0 +1,3 @@
+import { H3 as DripsyH3 } from 'dripsy';
+
+export const H3 = DripsyH3;

--- a/src/designs/atoms/Text/Text.stories.tsx
+++ b/src/designs/atoms/Text/Text.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { View } from 'dripsy';
+import { Text } from './Text';
+
+import type { ComponentProps } from 'react';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+export default {
+  title: 'components/Text',
+  component: Text,
+} as ComponentMeta<typeof Text>;
+
+type TextProps = ComponentProps<typeof Text>;
+type TextStory = ComponentStory<typeof Text>;
+
+const Template = (args: TextProps) => (
+  <View sx={{ flex: 1, padding: '$04' }}>
+    <Text {...args} />
+  </View>
+);
+
+export const Default: TextStory = (args: TextProps) => {
+  return <Template {...args} />;
+};
+
+Default.args = {
+  children: 'Text',
+};

--- a/src/designs/atoms/Text/Text.ts
+++ b/src/designs/atoms/Text/Text.ts
@@ -1,0 +1,8 @@
+import { Text as DripsyText } from 'dripsy';
+
+import type { ComponentPropsWithRef } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface TextProps extends ComponentPropsWithRef<typeof DripsyText> {}
+
+export const Text = DripsyText;

--- a/src/designs/atoms/Text/__tests__/Text.spec.tsx
+++ b/src/designs/atoms/Text/__tests__/Text.spec.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render as testRender, cleanup } from '@testing-library/react-native';
+import { withDripsy } from 'tests/utils';
+import { Text } from '../Text';
+
+import type { TextProps } from '../Text';
+
+const render = (props: TextProps): ReturnType<typeof testRender> =>
+  testRender(withDripsy(<Text {...props} />));
+
+describe('atoms/Text', () => {
+  const LABEL = 'Text';
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('렌더링 되었을 때', () => {  
+    it('스냅샷이 일치해야 한다', () => {
+      const tree = render({ children: LABEL }).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/designs/atoms/Text/__tests__/__snapshots__/Text.spec.tsx.snap
+++ b/src/designs/atoms/Text/__tests__/__snapshots__/Text.spec.tsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`atoms/Text 렌더링 되었을 때 스냅샷이 일치해야 한다 1`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "BMJUA",
+        "fontSize": 16,
+        "paddingBottom": 4,
+      },
+      undefined,
+      Object {},
+    ]
+  }
+>
+  Text
+</Text>
+`;

--- a/src/designs/atoms/Text/index.ts
+++ b/src/designs/atoms/Text/index.ts
@@ -1,0 +1,1 @@
+export * from './Text';

--- a/src/designs/atoms/Text/index.web.ts
+++ b/src/designs/atoms/Text/index.web.ts
@@ -1,0 +1,3 @@
+import { Text as DripsyText } from 'dripsy';
+
+export const Text = DripsyText;

--- a/src/designs/atoms/index.ts
+++ b/src/designs/atoms/index.ts
@@ -1,3 +1,7 @@
 export * from './Button';
 export * from './Input';
 export * from './Tag';
+export * from './Text';
+export * from './H1';
+export * from './H2';
+export * from './H3';

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -17,6 +17,8 @@ const FONT_NAME = Platform.select({
   default: 'BMJUA',
 });
 
+const overrideHeadingStyle = { fontWeight: 'normal' } as const;
+
 const themeLight = makeTheme({
   colors,
   customFonts: {
@@ -28,7 +30,6 @@ const themeLight = makeTheme({
   },
   fonts: {
     root: FONT_NAME,
-    heading: FONT_NAME,
   },
   fontSizes: {
     $default: ROOT_FONT_SIZE,
@@ -41,26 +42,27 @@ const themeLight = makeTheme({
     // Default text style
     body: {
       fontSize: ROOT_FONT_SIZE,
+      paddingBottom: '$01',
     },
     h1: {
+      marginVertical: 0,
+      paddingBottom: '$01',
       fontSize: '$h1',
-      mt: '$00',
-      mb: '$00',
     },
     h2: {
+      marginVertical: 0,
+      paddingBottom: '$01',
       fontSize: '$h2',
-      mt: '$00',
-      mb: '$00',
     },
     h3: {
+      marginVertical: 0,
+      paddingBottom: '$01',
       fontSize: '$h3',
-      mt: '$00',
-      mb: '$00',
     },
     p: {
+      marginVertical: 0,
+      paddingBottom: '$01',
       fontSize: '$text',
-      mt: '$00',
-      mb: '$00',
     },
     primary: {
       color: '$text_primary',
@@ -123,4 +125,4 @@ const themeDark: Theme = {
   ...themeLight,
 };
 
-export { themeLight, themeDark };
+export { themeLight, themeDark, overrideHeadingStyle };


### PR DESCRIPTION
# Description

iOS, Android 에서 커스텀 폰트 높이 이슈로 인해 정렬이 잘못되어 폰트가 잘리는 이슈가 있어 이를 수정함.

## Changes

- Heading, P 컴포넌트 기본 스타일 수정
- Heading 의 fontWeight 가 항상 bold 로 overriding 되는 이슈를 수정함
  - https://github.com/nandorojo/dripsy/issues/160

## Screenshots

| Platform | Preview |
|:---:|:---:|
| Web | ![image](https://user-images.githubusercontent.com/26512984/205975345-217c7754-13e5-4630-b609-808226a218dc.png) |
| Native | ![image](https://user-images.githubusercontent.com/26512984/205975170-d3b4bbbb-ff08-4a90-8943-cfc99746a47d.png) |

resolve #59