### PR TITLE
버튼 좌우 Adornment 추가 가능하도록 구현

### DIFF
--- a/src/designs/atoms/Button/Button.stories.tsx
+++ b/src/designs/atoms/Button/Button.stories.tsx
@@ -39,8 +39,32 @@ const Template = (args: ButtonProps) => (
   </View>
 );
 
+const DummyAdornment = () => (<View sx={{ width: 24, height: 24, backgroundColor: 'gray' } } />);
+
 export const $Default = Template.bind({});
 // @ts-ignore
 $Default.args = {
   label: 'Button',
+};
+
+export const $WithLeftAdornment = Template.bind({});
+// @ts-ignore
+$WithLeftAdornment.args = {
+  label: 'Left',
+  leftAdornment: <DummyAdornment />
+};
+
+export const $WithRightAdornment = Template.bind({});
+// @ts-ignore
+$WithRightAdornment.args = {
+  label: 'Right',
+  rightAdornment: <DummyAdornment />
+};
+
+export const $WithAdornments = Template.bind({});
+// @ts-ignore
+$WithAdornments.args = {
+  label: 'Both',
+  leftAdornment: <DummyAdornment />,
+  rightAdornment: <DummyAdornment />
 };

--- a/src/designs/atoms/Button/Button.tsx
+++ b/src/designs/atoms/Button/Button.tsx
@@ -21,6 +21,8 @@ export interface ButtonProps extends AccessibilityProps {
   disableHaptic?: boolean;
   disableLongPress?: boolean;
   containerStyle?: ViewStyle;
+  leftAdornment?: React.ReactElement,
+  rightAdornment?: React.ReactElement,
   onPress?: () => void;
   onLongPress?: () => void;
 }
@@ -40,12 +42,28 @@ const Shadow = styled(View)({
   borderRadius: '$md',
 });
 
+const Label = styled(Text, { 
+  defaultVariant: 'text.h2',
+})(({
+  isLightBackground,
+  hasAdornment,
+}: {
+  isLightBackground: boolean,
+  hasAdornment: boolean;
+}) => ({
+  width: hasAdornment ? 'auto' : '100%',
+  color: isLightBackground ? '$text_primary' : '$white',
+  textAlign: 'center',
+}));
+
 export function Button ({
   label,
   color,
   containerStyle,
   disableHaptic = false,
   disableLongPress = false,
+  leftAdornment,
+  rightAdornment,
   accessibilityHint,
   accessibilityLabel,
   accessibilityState,
@@ -64,14 +82,15 @@ export function Button ({
     onPress,
     onLongPress
   });
-  const isLightColor = isLight(color);
-  const labelVariant = isLightColor ? 'primary' : 'white';
-  const dimColor = isLightColor ? '$black' : '$white';
+  const isLightBackground = isLight(color);
+  const dimColor = isLightBackground ? '$black' : '$white';
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const capStyle = sx({
     display: 'flex',
-    justifyContent: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingX: '$04',
     alignItems: 'center',
     width: '100%',
     height: '100%',
@@ -104,7 +123,14 @@ export function Button ({
         >
           <Shadow />
           <Animated.View style={[capStyle, animatedCapStyle]}>
-            <Text variants={[labelVariant, 'h2']}>{label}</Text>
+            {leftAdornment ? leftAdornment : null}
+            <Label
+              hasAdornment={Boolean(leftAdornment || rightAdornment)}
+              isLightBackground={isLightBackground}
+            >
+              {label}
+            </Label>
+            {rightAdornment ? rightAdornment : null}
           </Animated.View>
           <Animated.View style={[dimStyle, animatedDimStyle]} />
         </Container>


### PR DESCRIPTION
# Description

버튼 좌우 Adornment 추가 가능하도록 구현

## Changes

- leftAdornment 및 rightAdornment props 추가
- 스토리북 업데이트

## Screenshots

<img width="542" alt="image" src="https://user-images.githubusercontent.com/26512984/212531584-8555d3d5-757e-4fde-a7f6-5c46c9af7ac2.png">

close #71