### PR TITLE
하단 탭 터치 영역 수정

### DIFF
--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -11,6 +11,12 @@ import type { BottomTabBarProps } from '@react-navigation/bottom-tabs';
 export const TAB_BAR_HEIGHT = 70;
 export const TAB_BAR_MIN_WIDTH = 250;
 export const BORDER_WIDTH = 2;
+const TAB_HIT_SLOP = {
+  top: 10,
+  bottom: 10,
+  left: 16,
+  right: 16,
+};
 
 const BottomFixedArea = styled(View)({
   position: 'absolute',
@@ -84,6 +90,7 @@ export function TabBar ({ state, descriptors, navigation }: BottomTabBarProps): 
               accessibilityLabel={options.tabBarAccessibilityLabel}
               accessibilityRole="button"
               accessibilityState={isFocused ? { selected: true } : {}}
+              hitSlop={TAB_HIT_SLOP}
               key={route.name}
               onLongPress={onLongPress}
               onPress={onPress}


### PR DESCRIPTION
# Description

hit slop 추가하여 더 넓은 영역을 터치할 수 있도록 개선함

## Changes

- hit slop 추가 (세로 10, 가로 16)

## Screenshots


| Before | After |
|:---:|:---:|
| <img width="300" src="https://user-images.githubusercontent.com/26512984/216608111-e0b2d886-39c0-4c80-aea2-53e4e4e251d5.png"> | <img width="300" src="https://user-images.githubusercontent.com/26512984/216608224-ab642f19-0181-479c-965d-612aa4acfb32.png"> |

close #113