### PR TITLE
메인탭 스크린 타이틀 추가

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { NavigationContainer } from '@react-navigation/native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { DripsyProvider } from 'dripsy';
 import { navigationRef } from 'src/navigators/helpers';
+import { titleFormatter } from 'src/utils';
 import { themeLight } from 'src/themes';
 import type { PropsWithChildren } from 'react';
 
@@ -18,7 +19,10 @@ function AppProviders<T = unknown>({ children }: PropsWithChildren<T>): JSX.Elem
     <GestureHandlerRootView style={gestureHandlerStyle}>
       <SafeAreaProvider>
         <DripsyProvider theme={themeLight}>
-          <NavigationContainer ref={navigationRef}>
+          <NavigationContainer
+            documentTitle={{ formatter: titleFormatter }}
+            ref={navigationRef}
+          >
             {children}
           </NavigationContainer>
         </DripsyProvider>

--- a/src/navigators/MainTab/MainTab.tsx
+++ b/src/navigators/MainTab/MainTab.tsx
@@ -8,6 +8,7 @@ import {
   Profile as ProfileScreen,
   Home as HomeScreen
 } from 'src/screens';
+import { t } from 'src/translations';
 
 import type { MainTabScreenParamList } from './types';
 
@@ -22,6 +23,7 @@ export function MainTabNavigator(): JSX.Element {
   const { bottom } = useSafeAreaInsets();
 
   const tabBarOptions = useMemo(() => ({
+    title: '',
     headerShown: false,
     tabBarShowLabel: false,
     tabBarActiveTintColor: theme.colors.$brand,
@@ -45,17 +47,26 @@ export function MainTabNavigator(): JSX.Element {
       <MainTab.Screen
         component={ProfileScreen}
         name="Profile"
-        options={{ tabBarIcon: Profile }}
+        options={{
+          title: t('title.profile'),
+          tabBarIcon: Profile,
+        }}
       />
       <MainTab.Screen
         component={HomeScreen}
         name="Home"
-        options={{ tabBarIcon: Home }}
+        options={{
+          title: t('title.home'),
+          tabBarIcon: Home,
+        }}
       />
       <MainTab.Screen
         component={Empty}
         name="Menu"
-        options={{ tabBarIcon: Menu }}
+        options={{
+          title: t('title.menu'),
+          tabBarIcon: Menu,
+        }}
       />
     </MainTab.Navigator>
   );

--- a/src/translations/ko.json
+++ b/src/translations/ko.json
@@ -16,7 +16,9 @@
       "landing": "환영합니다",
       "register_user": "도전자 등록하기",
       "quest_in_progress": "진행중인 퀘스트",
-      "profile": "프로필 정보"
+      "profile": "프로필 정보",
+      "home": "홈",
+      "menu": "메뉴"
     },
     "placeholder": {
       "enter_name": "이름을 입력해주세요"

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './async';
 export * from './common';
 export * from './locales';
+export * from './navigation';

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,11 @@
+import { name as appName } from '../../app.json';
+
+import type { DocumentTitleOptions } from '@react-navigation/native';
+
+export const titleFormatter: DocumentTitleOptions['formatter'] = (
+  options,
+  route,
+): string => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return options?.title ?? route?.name ?? appName;
+};


### PR DESCRIPTION
# Description

웹 환경에서 노출되는 상단 타이틀을 위해 각 스크린마다 타이틀을 추가함

## Changes

- 메인탭 하위 스크린에 타이틀 추가

## Screenshots

(Before)
![image](https://user-images.githubusercontent.com/26512984/216987907-1f1397cd-2008-4cb8-8e1f-d869742124fd.png)

(After)
![image](https://user-images.githubusercontent.com/26512984/216995876-87634934-39d8-4e3c-b655-e286f76db15b.png)


close #100