### PR TITLE
태블릿 해상도 대응

### DIFF
--- a/ios/Up.xcodeproj/project.pbxproj
+++ b/ios/Up.xcodeproj/project.pbxproj
@@ -529,8 +529,12 @@
 				PRODUCT_BUNDLE_IDENTIFIER = dev.geundung.up;
 				PRODUCT_NAME = Up;
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -560,7 +564,11 @@
 				PRODUCT_BUNDLE_IDENTIFIER = dev.geundung.up;
 				PRODUCT_NAME = Up;
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -31,7 +31,7 @@ const Container = styled(View)({
   alignSelf: 'center',
   width: '50%',
   minWidth: TAB_BAR_MIN_WIDTH,
-  maxWidth: CONTAINER_MAX_WIDTH,
+  maxWidth: CONTAINER_MAX_WIDTH / 2,
   height: TAB_BAR_HEIGHT,
   padding: '$04',
   borderRadius: '$full',

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -108,6 +108,7 @@ const themeLight = makeTheme({
       flex: 1,
       px: '$04',
       backgroundColor: '$white',
+      alignSelf: 'center',
     },
     // Container variants
     wide: {


### PR DESCRIPTION
# Description

태블릿에서 레이아웃이 정상적으로 유지되도록 수정

## Changes

- 큰 디스플레이에서 컨테이너가 중앙 정렬되도록 수정

## Screenshots

| Before | After |
|:--:|:--:|
| ![Simulator Screen Shot - iPad mini (6th generation) - 2023-03-08 at 23 18 59](https://user-images.githubusercontent.com/26512984/223740753-2929021c-dcc8-4b55-b828-e2af03d447ec.png) | ![Simulator Screen Shot - iPad mini (6th generation) - 2023-03-08 at 23 22 56](https://user-images.githubusercontent.com/26512984/223740829-6645c7c4-01ec-468e-b0ed-a1f758d0b4a2.png) |

close #189