### PR TITLE
버튼 핸들러 참조가 변경되지 않던 문제 수정

### DIFF
--- a/src/screens/RegisterUser/RegisterUserScreen.tsx
+++ b/src/screens/RegisterUser/RegisterUserScreen.tsx
@@ -1,36 +1,24 @@
-import React, { useState } from 'react';
-import { View } from 'react-native';
+import React from 'react';
 import { useActor } from '@xstate/react';
-import { styled } from 'dripsy';
-import { CommonLayout, Button, Input, H1 } from 'src/designs';
 import { AppManager } from 'src/modules';
 import * as AppHelpers from 'src/modules/app/helpers';
-import { t } from 'src/translations';
+import { RegisterUser } from './RegisterUser';
 
 import type { RootStackProps } from 'src/navigators/RootStack/types';
 
 type RegisterUserScreenProps = RootStackProps<'RegisterUser'>;
 
-const PageTitleArea = styled(View)({
-  paddingY: '$04',
-});
-
 
 export function RegisterUserScreen({
   navigation
 }: RegisterUserScreenProps): JSX.Element {
-  const [userName, setUserName] = useState('');
   const [_, send] = useActor(AppManager.getInstance().getService());
 
   const handlePressBackButton = (): void => {
     navigation.goBack();
   };
 
-  const handleChangeUserName = (name: string): void => {
-    setUserName(name);
-  };
-
-  const handlePressStartButton = (): void => {
+  const handlePressStartButton = (userName: string): void => {
     send({
       type: 'LOGIN',
       user: AppHelpers.createUserData(userName),
@@ -38,27 +26,9 @@ export function RegisterUserScreen({
   };
 
   return (
-    <CommonLayout keyboardAvoiding>
-      <CommonLayout.Header onBackPress={handlePressBackButton} />
-      <CommonLayout.Body scrollEnabled={false}>
-        <PageTitleArea>
-          <H1 variant="primary">{t('message.enter_name')}</H1>
-        </PageTitleArea>
-        <Input
-          onChangeText={handleChangeUserName}
-          placeholder={t('placeholder.enter_name')}
-        />
-      </CommonLayout.Body>
-      <CommonLayout.Footer>
-        <Button
-          color="$brand"
-          disableLongPress
-          disabled={userName.length < 2}
-          onPress={handlePressStartButton}
-        >
-          {t('label.go_level_up')}
-        </Button>
-      </CommonLayout.Footer>
-    </CommonLayout>
+    <RegisterUser
+      onPressBack={handlePressBackButton}
+      onPressStart={handlePressStartButton}
+    />
   );
 }


### PR DESCRIPTION
# Description

버튼 핸들러 참조가 변경되지 않아 사용자 등록 시 이름이 누락되던 문제를 수정함

## Changes

- PanResponder 의 경우 useRef 값이기 때문에 최초 렌더링 이후 변경되지 않음
- 그러나, onPress 및 onLongPress 의 경우 변경될 수 있음
  - Panresponder 에서 최초 렌더링 시점의 레퍼런스를 유지하고 있기에 버튼 핸들러가 stale 한 상태에서 변화하지 않아 특정 상태 참조가 불가한 문제가 발견됨
- useEffect 를 통해 최신 핸들러 레퍼런스를 저장하고 참조하도록 수정함

close #193