### PR TITLE
뱃지 렌더링 시 키 중복되던 문제 수정

### DIFF
--- a/src/screens/Profile/components/BadgeSection/BadgeSection.tsx
+++ b/src/screens/Profile/components/BadgeSection/BadgeSection.tsx
@@ -75,7 +75,8 @@ export const BadgeSection = memo(function BadgeSection ({
   };
 
   const isUnlocked = (id: number): boolean => {
-    return id !== 0 && !unlockedBadges[id];
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+    return id === 0 || unlockedBadges[id];
   };
 
   return (
@@ -88,7 +89,7 @@ export const BadgeSection = memo(function BadgeSection ({
               <Button
                 color="$white"
                 containerStyle={buttonContainerStyle}
-                disabled={isUnlocked(badge.id)}
+                disabled={!isUnlocked(badge.id)}
                 key={badge.id}
                 onLongPress={(): void => onLongPressBadge(badge.id)}
                 onPress={(): void => onPressBadge(badge.id)}


### PR DESCRIPTION
# Description

동일한 키를 사용하여 렌더링되고 있어 이를 수정합니다

## Changes

- badge.id 를 키로 사용하도록 변경

close #192